### PR TITLE
Update config.json

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -14,7 +14,7 @@
   "price": "",
   "timezone": "",
   "hostnm": "evse-wifi",
-  "adminpwd": "adminadmin",
+  "adminpwd": "admin",
   "maxinstall": "10",
   "buttonactive": false,
   "avgconsumption": "11.5",

--- a/data/config.json
+++ b/data/config.json
@@ -17,6 +17,6 @@
   "adminpwd": "adminadmin",
   "maxinstall": "10",
   "buttonactive": false,
-  "avgconsumption": "11.5"
+  "avgconsumption": "11.5",
   "wsauth": false
 }


### PR DESCRIPTION
The default config.json can not be used, as there is a colon missing at the end of line "avgconsumption": "11.5". JSON library reports "[ WARN ] Failed to parse config file"

Must read "avgconsumption": "11.5", to fix the problem.