### PR TITLE
Support PlatformIO and add ESP32 platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/P
 .pioenvs
 .piolibdeps
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 data/P
+.pioenvs
+.piolibdeps

--- a/SimpleEVSE-WiFi.ino
+++ b/SimpleEVSE-WiFi.ino
@@ -12,13 +12,24 @@
   THE SOFTWARE. 
 */
 
-#include <ESP8266WiFi.h>              // Whole thing is about using Wi-Fi networks
+// #include <Arduino.h>
+
+#ifdef ESP8266
+#include <ESP8266WiFi.h> // Whole thing is about using Wi-Fi networks
+#include <ESP8266mDNS.h> // Zero-config Library (Bonjour, Avahi)
+#include <ESPAsyncTCP.h> // Async TCP Library is mandatory for Async Web Server
+#endif
+
+#ifdef ESP32
+#include <WiFi.h>
+#include <SPIFFS.h>
+#include <ESPmDNS.h>
+#endif
+
 #include <SPI.h>                      // RFID MFRC522 Module uses SPI protocol
-#include <ESP8266mDNS.h>              // Zero-config Library (Bonjour, Avahi)
 #include <MFRC522.h>                  // Library for Mifare RC522 Devices
 #include <ArduinoJson.h>              // JSON Library for Encoding and Parsing Json object to send browser
 #include <FS.h>                       // SPIFFS Library for storing web files to serve to web browsers
-#include <ESPAsyncTCP.h>              // Async TCP Library is mandatory for Async Web Server
 #include <ESPAsyncWebServer.h>        // Async Web Server with built-in WebSocket Plug-in
 #include <SPIFFSEditor.h>             // This creates a web page on server which can be used to edit text based files
 #include <TimeLib.h>                  // Library for converting epochtime to a date

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,44 @@
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+; env_default=esp8266
+; env_default=esp32
+src_dir=.
+
+[common]
+lib_deps=
+    ArduinoJson@^5.1
+    EspSoftwareSerial@5.0.4
+    ESP Async WebServer@^1.2
+    Hash
+    MFRC522@^1.4
+    ModbusMaster@^2.0
+    SPI
+    Time@^1.5
+
+[env:esp8266]
+platform=espressif8266
+#board=esp01_1m
+board=d1_mini_pro
+framework=arduino
+lib_deps=
+    ${common.lib_deps}
+    ESPAsyncUDP
+lib_compat_mode=strict
+lib_ldf_mode=deep
+
+[env:esp32]
+platform=espressif32
+# stage version
+#platform=https://github.com/platformio/platform-espressif32.git
+board=featheresp32
+framework=arduino
+lib_compat_mode=strict
+lib_ldf_mode=deep
+lib_deps=
+    ${common.lib_deps}
+    https://github.com/me-no-dev/AsyncTCP
+    AsyncUDP
+    SPIFFS
+    FS

--- a/src/Ntp.cpp
+++ b/src/Ntp.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "Ntp.h"
-#include <ESPAsyncUDP.h>
 
 char * NtpClient::TimeServerName;
 int8_t NtpClient::timezone;

--- a/src/Ntp.h
+++ b/src/Ntp.h
@@ -8,8 +8,16 @@
 #ifndef NTP_H_
 #define NTP_H_
 
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 #include <ESPAsyncUDP.h>
+#endif
+
+#ifdef ESP32
+#include <WiFi.h>
+#include <AsyncUDP.h>
+#endif
+
 #include <TimeLib.h>
 
 #define NTP_PACKET_SIZE 48


### PR DESCRIPTION
This PR basically adds a `platformio.ini` and conditional defines for the required libraries. ESP32 compile however is still broken until https://github.com/espressif/arduino-esp32/pull/2837 is resolved.