### PR TITLE
Does not compile for ESP8266 Wemos D1 mini due to missing libraries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ lib_deps =
 	miguelbalboa/MFRC522@^1.4.7
 	plerup/EspSoftwareSerial@>=6.7.1
 	bblanchon/ArduinoJson@^6.16.1
-	emelianov/modbus-esp8266 @ ^3.0.3
+	emelianov/modbus-esp8266@^3.0.3
 	me-no-dev/ESPAsyncUDP@0.0.0-alpha+sha.697c75a025
 
 [env:d1_mini]
@@ -35,6 +35,7 @@ lib_deps =
 	miguelbalboa/MFRC522@^1.4.7
 	plerup/EspSoftwareSerial@>=6.7.1
 	bblanchon/ArduinoJson@^6.16.1
+	emelianov/modbus-esp8266@^3.0.3
 	paulstoffregen/Time
 	gmag11/NtpClientLib@^2.5.1
 	https://github.com/dancol90/ESP8266Ping.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ lib_deps =
 	plerup/EspSoftwareSerial@>=6.7.1
 	bblanchon/ArduinoJson@^6.16.1
 	emelianov/modbus-esp8266 @ ^3.0.3
+	me-no-dev/ESPAsyncUDP@0.0.0-alpha+sha.697c75a025
 
 [env:d1_mini]
 platform = espressif8266
@@ -34,4 +35,9 @@ lib_deps =
 	miguelbalboa/MFRC522@^1.4.7
 	plerup/EspSoftwareSerial@>=6.7.1
 	bblanchon/ArduinoJson@^6.16.1
-	emelianov/modbus-esp8266 @ ^3.0.3
+	paulstoffregen/Time
+	gmag11/NtpClientLib@^2.5.1
+	https://github.com/dancol90/ESP8266Ping.git
+	me-no-dev/ESPAsyncUDP@0.0.0-alpha+sha.697c75a025
+	ottowinter/ESPAsyncWebServer-esphome@^1.2.7
+	https://github.com/CurtRod/ModbusMaster.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,8 @@
 #include "esp_spiffs.h"
 #include "esp_wifi.h"
 #include "oled.h"
+#endif
+
 
 #include <TimeLib.h>                  // Library for converting epochtime to a date
 #include <SPI.h>                      // SPI protocol
@@ -60,6 +62,7 @@ String swVersion = String(sw_maj) + "." + String(sw_min) + "." + String(sw_rev);
 #else
 uint8_t sw_maj = 2; //Firmware Major Version
 String swVersion = String(sw_maj) + "." + String(sw_min) + "." + String(sw_rev);
+#endif
 
 //////////////////////////////////////////////////////////////////////////////////////////
 ///////       Variables For Whole Scope


### PR DESCRIPTION
SimpleEVSE-WiFi does not compile for Wemost D1 mini in Platformio due to missing libraries. This pull request adds the required libraries back in and adds two missing #endifs to enable the ESP8266 code blocks in main.cpp