### PR TITLE
Platformio config

### DIFF
--- a/PinConfig.md
+++ b/PinConfig.md
@@ -1,0 +1,42 @@
+# pins EVSE-WIFI
+
+
+|Module|Module PIN|EVSE-Wifi 1.0<br/>Wemos D1 Mini|EVSE-Wifi 2.0<br/>Wemos D1 Mini32|GND|3.3v|Remark
+|:----|:-:|:-----:|:-----:|:-:|:-:|:------------------------|
+|LED EVSE-WIFI|+|D0|26|x||optional
+|EVSE (*1)|TX|D1||||using SoftwareSerial
+|EVSE (*1)|RX|D2||||using SoftwareSerial
+|RS485|TX|TX (*1)|22|x|x|Modbus interface
+|RS485|RX|RX (*1)|21|||Modbus Interface
+|EVSE (*1)|A|-|-|||using RS485 bus A, bus-id=1
+|EVSE (*1)|B|-|-|||using RS485 bus B, bus-id=1
+|SDM120<br/>SDM630|A|||||optional, using RS485 bus A, bus-id=2
+|SDM120<br/>SDM630|B|||||optional, using RS485 bus B, bus-id=2
+|S0 Meter|S0+|D3|17|||optional
+|S0 Meter|S0-|||x||optional
+|Button (Charge)||D4|16|x||optional
+|Button (Reset)||Rst|Rst|x||optional
+|RFID|Base|||x|x|
+|RFID|SCK|D5|18|||(*2)
+|RFID|MISO|D6|19|||(*2)
+|RFID|MOSI|D7|23|||(*2)
+|RFID|SS (SDA)|D8|5|||(*2)
+|CPInt|S||4|x|x|(*5)
+|RSE|||2|||(*3)
+|Oled SSD1327|base|||x|x|optional (*4)
+|Oled SSD1327|CS||12||||
+|Oled SSD1327|DC||13||||
+|Oled SSD1327|DIN (MOSI)||18||||
+|Oled SSD1327|CLK (SCK)||23||||
+|Oled SSD1327|reset||33||||
+
+
+(*1) EVSE connection: 
+* in 8266 (EVSE-WIFI 1.0) the EVSE is connected using SoftwareSerial on D1/D2, and RS485 is always enabled on TXD/RXD. The Modbus Meter (SDM120/630) is always connected using the RS485 adapter on TXD/RXD.
+* EVSE-WIFI 2.0 and SmartWB the RS485 is connected over 22/21 using HardwareSerial. EVSE and ModbusMeters are connected over RS485 only / always.  
+EVSE has different connectors for Modbus and Serial input, so this is not directly pin compatible.  
+
+(*2) RFID uses always first SPI (VSPI) pins from board. Cannot be changed.  
+(*3) "Rundsteuerempfänger" (receiver for external control), SmartWB only. Extra hardware required.  
+(*4) the default display is a WaveShare SSD1327 connected using 4wire SPI interface and uses the VSPI hardware interface (shared with RFID SPI bus). The graphics library (u8g2) does not fit into ESP8266 memory in this setup, therefore supported on ESP32 only. Using different SPI (HSPI) requires using 13/14 for DIN and CLK, causing other pin conflicts. See here: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/spi_master.html  
+(*5) CPInt (CP Interrupt) simulates disconnecting / connecting charger from car and is required for some car models which will fall asleep after some time of inactivity on charge port. Using CPInt requires connecting a relais, which will be connected in between EVSE CP pin and CP wire to car connector

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Compiled firmware binary and flasher tool for Windows PCs are available in on ww
 
 [Download Firmware](https://www.evse-wifi.de/download/)
 
-#### Building From Source
+#### Building From Source using Arduino
 Please install Arduino IDE if you didn't already, then add ESP8266 Core on top of it. Additional Library download links are listed below:
 
 * [Arduino IDE](http://www.arduino.cc) - The development IDE
@@ -163,6 +163,14 @@ You also need to upload web files to your ESP with ESP8266FS Uploader.
 * [ESP8266FS Uploader](https://github.com/esp8266/arduino-esp8266fs-plugin) - Arduino ESP8266 filesystem uploader
 
 Unlisted libraries are part of [ESP8266](https://github.com/esp8266/Arduino) Core for Arduino IDE, so you don't need to download them, but check that at least you have v2.4.0 or above installed.
+
+#### Building from source using vscode
+Install VSCode and install platformio plugin in vscode (plugins|recommended plugins). Open the project in VSCode, select the platformio extension on the left, and in project tasks select your board to build, upload etc.
+When building, all required libraries will be downloaded automatically.
+
+* [vscode](https://code.visualstudio.com/) - visual studio code
+
+**Windows platform for ESP32:** there is a flaw in AsyncWebserver building on Windows. To fix this, after first build (which fails) go to `.pio/libdeps/<your platform>/Time` and rename the `Time.h` to `_Time.h`. You need to repeat this whenever you downloaded this library again.
 
 ## First boot
 When SimpleEVSE-WiFi starts for the first time it sets up a WiFi access point called 'evse-wifi'. You can connect without a password. To connect, open http://192.168.4.1 in your browser. The initial password is 'adminadmin'. You should first check the Settings to bring the ESP in Client mode and connect it to your local WiFi network. The ESP will be restarted afterwards. If it doesn't restart, press the 'RST' button once. Sometimes the ESP must first be manually reset (this only has to happen after flashing a new firmware).

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,3 +44,38 @@ lib_deps =
 	; see Readme why using project specific library
 	https://github.com/CurtRod/ModbusMaster
 
+[env:az-delivery-devkit-v4]
+; windows: rename in .pio/libdeps/.../Time/Time.h to _Time.h
+platform = espressif32
+board = az-delivery-devkit-v4
+framework = arduino
+upload_speed = 921600
+board_build.partitions = min_spiffs.csv
+board_build.f_cpu = 160000000L
+lib_ignore =
+lib_deps =
+	miguelbalboa/MFRC522
+	ArduinoJson
+	modbus-esp8266
+	; see Readme why using project specific library
+	https://github.com/CurtRod/ModbusMaster
+	ESPAsyncWebServer-esphome
+	Time
+	U8g2
+
+[env:nodemcuv2_8266]
+platform = espressif8266
+board = nodemcuv2
+framework = arduino
+upload_speed = 921600
+build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY -Wl,-Map,output.map
+lib_ignore =
+lib_deps =
+	miguelbalboa/MFRC522
+	ArduinoJson
+	modbus-esp8266
+	ESPAsyncUDP
+	Time
+	ESPAsyncWebServer-esphome
+	; see Readme why using project specific library
+	https://github.com/CurtRod/ModbusMaster

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,19 +9,23 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:wemos_d1_mini32]
+; windows: rename in .pio/libdeps/.../Time/Time.h to _Time.h
 platform = espressif32
 board = wemos_d1_mini32
 framework = arduino
 upload_speed = 921600
-lib_ignore = 
-	ESPAsyncUDP
-	EspSoftwareSerial
 board_build.partitions = min_spiffs.csv
 board_build.f_cpu = 160000000L
-lib_deps = 
-	miguelbalboa/MFRC522@^1.4.7
-	bblanchon/ArduinoJson@^6.16.1
+lib_ignore =
+lib_deps =
+	miguelbalboa/MFRC522 @ ^1.4.7
+	bblanchon/ArduinoJson @ ^6.16.1
 	emelianov/modbus-esp8266 @ ^3.0.3
+	; see Readme why using project specific library
+	https://github.com/CurtRod/ModbusMaster
+	ESPAsyncWebServer-esphome
+	Time
+	U8g2
 
 [env:d1_mini]
 platform = espressif8266
@@ -29,9 +33,14 @@ board = d1_mini
 framework = arduino
 upload_speed = 921600
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY -Wl,-Map,output.map
-lib_ignore = U8g2
+lib_ignore =
 lib_deps = 
-	miguelbalboa/MFRC522@^1.4.7
-	plerup/EspSoftwareSerial@>=6.7.1
-	bblanchon/ArduinoJson@^6.16.1
+	miguelbalboa/MFRC522 @ ^1.4.7
+	bblanchon/ArduinoJson @ ^6.16.1
 	emelianov/modbus-esp8266 @ ^3.0.3
+	ESPAsyncUDP
+	Time
+	ESPAsyncWebServer-esphome
+	; see Readme why using project specific library
+	https://github.com/CurtRod/ModbusMaster
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,19 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+default_envs = wemos_d1_mini32
+
+[common_env_data]
+lib_deps =
+	miguelbalboa/MFRC522 @ ^1.4.7
+	bblanchon/ArduinoJson @ ^6.16.1
+	emelianov/modbus-esp8266 @ ^3.0.3
+	; see Readme why using this project specific library
+	https://github.com/CurtRod/ModbusMaster
+	ESPAsyncWebServer-esphome
+	Time
+
 [env:wemos_d1_mini32]
 ; windows: rename in .pio/libdeps/.../Time/Time.h to _Time.h
 platform = espressif32
@@ -18,13 +31,7 @@ board_build.partitions = min_spiffs.csv
 board_build.f_cpu = 160000000L
 lib_ignore =
 lib_deps =
-	miguelbalboa/MFRC522 @ ^1.4.7
-	bblanchon/ArduinoJson @ ^6.16.1
-	emelianov/modbus-esp8266 @ ^3.0.3
-	; see Readme why using project specific library
-	https://github.com/CurtRod/ModbusMaster
-	ESPAsyncWebServer-esphome
-	Time
+	${common_env_data.lib_deps}
 	U8g2
 
 [env:d1_mini]
@@ -35,14 +42,8 @@ upload_speed = 921600
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY -Wl,-Map,output.map
 lib_ignore =
 lib_deps = 
-	miguelbalboa/MFRC522 @ ^1.4.7
-	bblanchon/ArduinoJson @ ^6.16.1
-	emelianov/modbus-esp8266 @ ^3.0.3
+	${common_env_data.lib_deps}
 	ESPAsyncUDP
-	Time
-	ESPAsyncWebServer-esphome
-	; see Readme why using project specific library
-	https://github.com/CurtRod/ModbusMaster
 
 [env:az-delivery-devkit-v4]
 ; windows: rename in .pio/libdeps/.../Time/Time.h to _Time.h
@@ -54,13 +55,7 @@ board_build.partitions = min_spiffs.csv
 board_build.f_cpu = 160000000L
 lib_ignore =
 lib_deps =
-	miguelbalboa/MFRC522
-	ArduinoJson
-	modbus-esp8266
-	; see Readme why using project specific library
-	https://github.com/CurtRod/ModbusMaster
-	ESPAsyncWebServer-esphome
-	Time
+	${common_env_data.lib_deps}
 	U8g2
 
 [env:nodemcuv2_8266]
@@ -71,11 +66,5 @@ upload_speed = 921600
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY -Wl,-Map,output.map
 lib_ignore =
 lib_deps =
-	miguelbalboa/MFRC522
-	ArduinoJson
-	modbus-esp8266
+	${common_env_data.lib_deps}
 	ESPAsyncUDP
-	Time
-	ESPAsyncWebServer-esphome
-	; see Readme why using project specific library
-	https://github.com/CurtRod/ModbusMaster


### PR DESCRIPTION
wemos_d1_mini and d1_mini_32 build also on windows, no need for arduino install.
    
- using default libraries, where possible
- does not require installation of arduino IDE, just VSCode + platformio plugin
- unused libs will be stripped automatically from binary from compiler, no need to specifically exclude them
- remark: on windows rename the .pio/libdeps/wemos_d1_mini32/Time/time.h (or any ESP32) to _time.h for building
  its seems a problem with the webserver library on windows

Also adds environments for AZ Delivery V4 (ESP32) and NodeMCUV2 (ESP8266) in a separate commit

Builds Tested on Windows and Ubuntu.